### PR TITLE
更新依赖版本，调整部分语法以兼容新版laravel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.1
+  - 7.2
   - 7.3
   - hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.3
   - hhvm
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": ">=5.6.4",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
-        "guzzlehttp/guzzle": "^7.0.1",
         "guzzlehttp/promises": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": "^7.1",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
         "guzzlehttp/promises": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
-        "guzzlehttp/promises": "^1.0"
+        "guzzlehttp/promises": "^1.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^8.0|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,12 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/support": "~5.1",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
+        "guzzlehttp/guzzle": "^7.0.1",
         "guzzlehttp/promises": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
     "suggest": {
         "laravel/framework": "To test the Laravel bindings",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,8 +8,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="true">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Preq Test Suite">
             <directory suffix="Test.php">./tests</directory>

--- a/src/AbstractCommand.php
+++ b/src/AbstractCommand.php
@@ -11,7 +11,7 @@ use Per3evere\Preq\Contract\Command as CommandContract;
 use Illuminate\Support\Arr;
 use Throwable;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Promise\promise_for;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Exception\ClientException;
 
 abstract class AbstractCommand implements CommandContract
@@ -298,7 +298,7 @@ abstract class AbstractCommand implements CommandContract
 
                     $this->executionException = $reason;
                     $this->recordExecutionEvent(self::EVENT_FAILURE);
-                    return promise_for($this->getFallbackOrThrowException($reason));
+                    return Create::promiseFor($this->getFallbackOrThrowException($reason));
                 }
             );
 

--- a/src/IlluminateStateStorage.php
+++ b/src/IlluminateStateStorage.php
@@ -34,7 +34,6 @@ class IlluminateStateStorage implements StateStorageContract
 
     protected function prefix($name)
     {
-        //$this->cache->setPrefix('');
         return self::CACHE_PREFIX . '_' . $name;
     }
 

--- a/src/IlluminateStateStorage.php
+++ b/src/IlluminateStateStorage.php
@@ -34,6 +34,9 @@ class IlluminateStateStorage implements StateStorageContract
 
     protected function prefix($name)
     {
+        if (method_exists($this->cache, 'setPrefix')) {
+            $this->cache->setPrefix('');
+        }
         return self::CACHE_PREFIX . '_' . $name;
     }
 

--- a/src/IlluminateStateStorage.php
+++ b/src/IlluminateStateStorage.php
@@ -34,7 +34,7 @@ class IlluminateStateStorage implements StateStorageContract
 
     protected function prefix($name)
     {
-        $this->cache->setPrefix('');
+        //$this->cache->setPrefix('');
         return self::CACHE_PREFIX . '_' . $name;
     }
 

--- a/src/IlluminateStateStorage.php
+++ b/src/IlluminateStateStorage.php
@@ -7,7 +7,7 @@ use Per3evere\Preq\Contract\StateStorage as StateStorageContract;
 
 class IlluminateStateStorage implements StateStorageContract
 {
-    const BUCKET_EXPIRE_MINUTES = 2;
+    const BUCKET_EXPIRE_SECONDS = 120;
 
     const CACHE_PREFIX = 'preq';
 
@@ -58,7 +58,7 @@ class IlluminateStateStorage implements StateStorageContract
     {
         $bucketName = $this->prefix($commandKey . '_' . $type . '_' . $index);
 
-        if (! $this->cache->add($bucketName, 1, self::BUCKET_EXPIRE_MINUTES)) {
+        if (! $this->cache->add($bucketName, 1, self::BUCKET_EXPIRE_SECONDS)) {
             $this->cache->increment($bucketName);
         }
     }
@@ -73,7 +73,7 @@ class IlluminateStateStorage implements StateStorageContract
         $bucketName = $this->prefix($commandKey . '_' . $type . '_' . $index);
 
         if ($this->cache->has($bucketName)) {
-            $this->cache->put($bucketName, 0, self::BUCKET_EXPIRE_MINUTES);
+            $this->cache->put($bucketName, 0, self::BUCKET_EXPIRE_SECONDS);
         }
     }
 
@@ -90,7 +90,7 @@ class IlluminateStateStorage implements StateStorageContract
         $this->cache->put($openedKey, true);
 
         $sleepingWindowInSeconds = ceil($sleepingWindowInMilliseconds / 1000);
-        $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds / 60);
+        $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds);
     }
 
     /**
@@ -104,7 +104,7 @@ class IlluminateStateStorage implements StateStorageContract
 
         $sleepingWindowInSeconds = ceil($sleepingWindowInMilliseconds / 1000);
 
-        return (boolean) $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds / 60);
+        return (boolean) $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds);
     }
 
     /**


### PR DESCRIPTION
#### 变更说明:
* `promise_for`已在新的`guzzlehttp/promises`版本中被丢弃，改为使用:
  ```
  use GuzzleHttp\Promise\Create;

  return Create::promiseFor($this->getFallbackOrThrowException($reason));
  ```
* 自`laravel/lumen 5.8`起`Cache`相关方法接受的第三个整型 ttl 单位由分钟改为秒([laravel 5.8 升级说明](https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds))，因此将`src/IlluminateStateStorage.php`中的`const BUCKET_EXPIRE_MINUTES = 2;`调整为`const BUCKET_EXPIRE_SECONDS = 120;`并去除了多余的单位换算步骤。
* 因不同 cache driver 的限制，去除了`src/IlluminateStateStorage.php`中`$this->cache->setPrefix('');`防止报错

#### 此次提交内容不再兼容`laravel/lumen 5.8`之前的版本。
